### PR TITLE
Add German, Polish, Spanish translations + fix English l10n

### DIFF
--- a/l10n/l10n_de.xml
+++ b/l10n/l10n_de.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<l10n>
+	<translationContributors>XelaNull (AI-assisted by Claude)</translationContributors>
+	<texts>
+		<text name="UNKNOWN" text="Unbekannt" />
+		<text name="input_SHOW_EMPLOYEE_MENU" text="Mitarbeitermenü anzeigen" />
+		<text name="EM_employee_management" text="Mitarbeiterverwaltung" />
+
+		<!-- Mitarbeiterverwaltung Übersetzungen (aus modDesc.xml) -->
+		<text name="em_skill_driving" text="Fahren" />
+		<text name="em_skill_harvesting" text="Ernten" />
+		<text name="em_skill_technical" text="Technik" />
+		<text name="em_assigned_vehicle" text="Zugewiesenes Fahrzeug" />
+		<text name="em_current_job" text="Aktuelle Aufgabe" />
+		<text name="em_status_available" text="Verfügbar" />
+		<text name="em_status_working" text="Arbeitet" />
+		<text name="em_action_hire" text="Einstellen" />
+		<text name="em_action_fire" text="Entlassen" />
+		<text name="em_action_assign_vehicle" text="Fahrzeug zuweisen" />
+		<text name="em_action_assign_job" text="Aufgabe zuweisen" />
+	</texts>
+</l10n>

--- a/l10n/l10n_en.xml
+++ b/l10n/l10n_en.xml
@@ -2,9 +2,9 @@
 <l10n>
 	<translationContributors>LeGrizzly</translationContributors>
 	<texts>
-		<text name="UNKNOWN" text="Inconnu" />
-		<text name="input_SHOW_EMPLOYEE_MENU" text="Afficher le menu des employés" />
-		<text name="EM_employee_management" text="Gestion des Employés" />
+		<text name="UNKNOWN" text="Unknown" />
+		<text name="input_SHOW_EMPLOYEE_MENU" text="Show Employee Menu" />
+		<text name="EM_employee_management" text="Employee Management" />
 
 		<!-- Employee Manager translations (from modDesc.xml) -->
 		<text name="em_skill_driving" text="Driving" />

--- a/l10n/l10n_es.xml
+++ b/l10n/l10n_es.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<l10n>
+	<translationContributors>XelaNull (AI-assisted by Claude)</translationContributors>
+	<texts>
+		<text name="UNKNOWN" text="Desconocido" />
+		<text name="input_SHOW_EMPLOYEE_MENU" text="Mostrar menú de empleados" />
+		<text name="EM_employee_management" text="Gestión de Empleados" />
+
+		<!-- Traducciones de Gestión de Empleados (desde modDesc.xml) -->
+		<text name="em_skill_driving" text="Conducción" />
+		<text name="em_skill_harvesting" text="Cosecha" />
+		<text name="em_skill_technical" text="Técnica" />
+		<text name="em_assigned_vehicle" text="Vehículo Asignado" />
+		<text name="em_current_job" text="Trabajo Actual" />
+		<text name="em_status_available" text="Disponible" />
+		<text name="em_status_working" text="Trabajando" />
+		<text name="em_action_hire" text="Contratar" />
+		<text name="em_action_fire" text="Despedir" />
+		<text name="em_action_assign_vehicle" text="Asignar Vehículo" />
+		<text name="em_action_assign_job" text="Asignar Trabajo" />
+	</texts>
+</l10n>

--- a/l10n/l10n_pl.xml
+++ b/l10n/l10n_pl.xml
@@ -1,0 +1,22 @@
+<?xml version='1.0' encoding='utf-8'?>
+<l10n>
+	<translationContributors>XelaNull (AI-assisted by Claude)</translationContributors>
+	<texts>
+		<text name="UNKNOWN" text="Nieznany" />
+		<text name="input_SHOW_EMPLOYEE_MENU" text="Pokaż menu pracowników" />
+		<text name="EM_employee_management" text="Zarządzanie Pracownikami" />
+
+		<!-- Tłumaczenia Zarządzania Pracownikami (z modDesc.xml) -->
+		<text name="em_skill_driving" text="Jazda" />
+		<text name="em_skill_harvesting" text="Żniwa" />
+		<text name="em_skill_technical" text="Technika" />
+		<text name="em_assigned_vehicle" text="Przypisany Pojazd" />
+		<text name="em_current_job" text="Bieżące Zadanie" />
+		<text name="em_status_available" text="Dostępny" />
+		<text name="em_status_working" text="Pracuje" />
+		<text name="em_action_hire" text="Zatrudnij" />
+		<text name="em_action_fire" text="Zwolnij" />
+		<text name="em_action_assign_vehicle" text="Przypisz Pojazd" />
+		<text name="em_action_assign_job" text="Przypisz Zadanie" />
+	</texts>
+</l10n>

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -5,10 +5,16 @@
     <title>
         <en><![CDATA[Advanced Employee Manager]]></en>
         <fr><![CDATA[Gestion Avancée des Employés]]></fr>
+        <de><![CDATA[Erweiterte Mitarbeiterverwaltung]]></de>
+        <pl><![CDATA[Zaawansowane Zarządzanie Pracownikami]]></pl>
+        <es><![CDATA[Gestión Avanzada de Empleados]]></es>
     </title>
     <description>
         <en><![CDATA[Bring a new level of depth to your farm's workforce. Hire and manage employees with unique skills to optimize your operations.]]></en>
         <fr><![CDATA[Apportez un nouveau niveau de profondeur à votre main-d'œuvre agricole. Embauchez et gérez des employés dotés de compétences uniques pour optimiser vos opérations.]]></fr>
+        <de><![CDATA[Verleihen Sie der Belegschaft Ihres Hofes mehr Tiefe. Stellen Sie Mitarbeiter mit einzigartigen Fähigkeiten ein und verwalten Sie sie, um Ihre Abläufe zu optimieren.]]></de>
+        <pl><![CDATA[Dodaj nowy poziom głębi do zarządzania siłą roboczą na Twojej farmie. Zatrudniaj i zarządzaj pracownikami o unikalnych umiejętnościach, aby zoptymalizować swoje operacje.]]></pl>
+        <es><![CDATA[Añade un nuevo nivel de profundidad a la fuerza laboral de tu granja. Contrata y gestiona empleados con habilidades únicas para optimizar tus operaciones.]]></es>
     </description>
 
     <iconFilename>icon_temporary.dds</iconFilename>


### PR DESCRIPTION
## Summary

- **Add 3 new language translations:** German (de), Polish (pl), Spanish (es)
- **Fix English l10n:** The first 3 entries in `l10n_en.xml` were French instead of English (`Inconnu` → `Unknown`, `Afficher le menu des employés` → `Show Employee Menu`, `Gestion des Employés` → `Employee Management`)
- **Update modDesc.xml:** Added `<title>` and `<description>` in de/pl/es

## Why These Languages?

These are the 3 most popular FS25 languages after English and French:

| Language | Why |
|----------|-----|
| **German (de)** | GIANTS Software's home market — largest FS community worldwide |
| **Polish (pl)** | Massive FS25 player base — Poland is one of the top FS markets |
| **Spanish (es)** | One of the largest global gaming communities |

## Files Changed

| File | Change |
|------|--------|
| `l10n/l10n_en.xml` | Fixed 3 entries that were French instead of English |
| `l10n/l10n_de.xml` | **New** — Complete German translation |
| `l10n/l10n_pl.xml` | **New** — Complete Polish translation |
| `l10n/l10n_es.xml` | **New** — Complete Spanish translation |
| `modDesc.xml` | Added de/pl/es title and description |

## Notes

- All translations follow the same XML structure as the existing en/fr files
- Translation contributors credited as `XelaNull (AI-assisted by Claude)`
- Translations were generated with AI assistance and reviewed for accuracy in gaming context

🤖 Generated with [Claude Code](https://claude.com/claude-code)